### PR TITLE
Fix white-on-gray links on mousedown in Chrome

### DIFF
--- a/prolog/toc.css
+++ b/prolog/toc.css
@@ -85,7 +85,7 @@ a.navigation {
     display: block;
 }    
 
-.toc-content a:hover, a:focus {
+.toc-content a:hover, .toc-content a:focus {
     background-color: #f1f1f1;
     text-decoration: underline;
 }


### PR DESCRIPTION
When I right click a link to open in a new tab, I get white-on-gray styling, so I added another CSS selector with the same styling as hovered links.