### PR TITLE
use library(http/http_server) in SWI HTTP Server

### DIFF
--- a/prolog/web.html
+++ b/prolog/web.html
@@ -183,8 +183,7 @@ etc.
     To get started, consider a very rudimentary HTTP&nbsp;server:
 
     <pre>
-:- use_module(library(http/thread_httpd)).
-:- use_module(library(http/http_dispatch)).
+:- use_module(library(http/http_server)).
 :- use_module(library(http/http_unix_daemon)).
 
 :- http_handler(/, handle_request, []).


### PR DESCRIPTION
The latest SWI-Prolog docs say that the single library(http/http_server) should be used, as it bundles in several other libraries that are typically needed.
See https://www.swi-prolog.org/pldoc/man?section=httpserver
And also the notes on the docs for the bundled in libraries, which now say
> Most code doesn't need to use this directly; instead use library(http/http_server), which combines this library with the typical HTTP libraries that most servers need.