### PR TITLE
Update pceprolog.html

### DIFF
--- a/pceprolog/pceprolog.html
+++ b/pceprolog/pceprolog.html
@@ -64,7 +64,7 @@
 
     <pre>
 (setq prolog-system 'swi
-      prolog-program-switches '((swi ("-G128M" "-T128M" "-L128M" "-O"))
+      prolog-program-switches '((swi ("-O"))
                                 (t nil))
       prolog-electric-if-then-else-flag t)
     </pre>


### PR DESCRIPTION
The SWI-Prolog's `-G`, `-T`, and `-L` program switches are not supported anymore.

See https://github.com/SWI-Prolog/swipl/commit/5efb31c72ad52d6d352f3131cf85061b40c17188

Only the `-O` remains useful.