### PR TITLE
Print URL when server starts

### DIFF
--- a/server.pl
+++ b/server.pl
@@ -47,6 +47,7 @@ server(Port) :-
         server('127.0.0.1', Port).
 
 server(IP, Port) :-
+        format("Listening on http://~w:~d/~n", [IP, Port]),
         socket_server_open(IP:Port, Socket),
         accept_loop(Socket).
 


### PR DESCRIPTION
Not much no say about the patch.

The server can't handle SIGINT on Linux, so Ctrl+C can't stop it. on_signal/2 doesn't seem to be in scryer_prolog.
***

Thanks for making this wonderful tutorial! It's very useful!