### PR TITLE
Fixed minor typo (nonterminal instead of predicate)

### DIFF
--- a/prolog/dcg.html
+++ b/prolog/dcg.html
@@ -255,7 +255,7 @@ seqq([Es|Ess]) --&gt;
     The grammar construct <tt>('|')//2</tt> and its
     equivalent&nbsp;<tt>(;)//2</tt> correspond to the Prolog control
     structure&nbsp;<tt>(;)/2</tt> and are read as "or". When parsing
-    with DCGs, using <tt>('|')/2</tt> is preferable over <tt>(;)//2</tt>
+    with DCGs, using <tt>('|')//2</tt> is preferable over <tt>(;)//2</tt>
     due to existing conventions for writing grammars.
 
     <br><br>


### PR DESCRIPTION
I believe it was meant to be a nonterminal indicator (//), rather than a Prolog predicate indicator (/).