### PR TITLE
Fix CQL link

### DIFF
--- a/prolog/business.html
+++ b/prolog/business.html
@@ -82,7 +82,7 @@
     <br><br>
 
     You can also use the <i>Constraint Query
-    Language</i>&nbsp;<a href="http://eu.swi-prolog.org/pldoc/doc/_SWI_/library/cql/cql.pl">CQL</a>
+    Language</i>&nbsp;<a href="https://eu.swi-prolog.org/pldoc/man?section=cql">CQL</a>
     to seamlessly access SQL&nbsp;databases from Prolog.
 
     <br><br>


### PR DESCRIPTION
The current CQL link returns a 403 Forbidden error. This updates the link to the current location of the SWI CQL library documentation.